### PR TITLE
A lot of pasls fixes made during the development of our VSCode plugin 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 *~
 /server/pasls
 /server/pasls.exe
+
+server/backup/

--- a/server/castlelsp.pas
+++ b/server/castlelsp.pas
@@ -194,7 +194,10 @@ function ExtraFpcOptions: String;
         if S.Startswith('-Fu', true) or
            S.Startswith('-Fi', true) then
         begin
-          Insert(CastleEnginePath, S, 4);
+          { Quotes added because the path to the engine may have spaces.
+            For example default AppData path on Windows }
+          Insert('"' + CastleEnginePath, S, 4);
+          S := S + '"';
           Result := Result + ' ' + S;
         end;
       end;

--- a/server/castlelsp.pas
+++ b/server/castlelsp.pas
@@ -27,9 +27,9 @@ uses Classes, IniFiles;
 
 var
   UserConfig: TIniFile;
-  WorkspacePaths: TStringList;
-  WorkspaceAndEnginePaths: TStringList;
-  EngineDeveloperMode: Boolean;
+  WorkspacePaths: TStringList; // paths to search by workspace symbols
+  WorkspaceAndEnginePaths: TStringList; // paths to search by workspace symbols in engine developer mode
+  EngineDeveloperMode: Boolean; // add engine paths to workspace symbols?
 
 procedure InitializeUserConfig;
 
@@ -42,6 +42,7 @@ procedure InitializeUserConfig;
 }
 function ExtraFpcOptions: String;
 
+{ Adds project search paths from manifest to workspace paths used by workspace symbols }
 procedure ParseWorkspacePaths(const ProjectSearchPaths, ProjectDirectory: String);
 
 implementation
@@ -78,6 +79,108 @@ begin
   UserConfig := TIniFile.Create(FileName);
 end;
 
+{ Check is Path a sensible CGE sources path.
+  Requires Path to end with PathDelim. }
+function CheckCastlePath(const Path: String): Boolean;
+begin
+  Result :=
+    DirectoryExists(Path + 'src') and
+    DirectoryExists(Path + 'tools' + PathDelim + 'build-tool' + PathDelim + 'data');
+end;
+
+function GetCastleEnginePathFromEnv: String;
+begin
+  Result := GetEnvironmentVariable('CASTLE_ENGINE_PATH');
+  if Result = '' then
+    Exit;
+
+  Result := IncludeTrailingPathDelimiter(Result);
+  if CheckCastlePath(Result) then
+    Exit;
+
+  Result := '';
+end;
+
+function ExeName: String;
+{$if defined(LINUX)}
+var
+  ExeLinkName: String;
+begin
+  ExeLinkName := '/proc/' + IntToStr(FpGetpid) + '/exe';
+  Result := FpReadLink(ExeLinkName);
+{$elseif defined(MSWINDOWS)}
+var
+  S: UnicodeString;
+begin
+  SetLength(S, MAX_PATH);
+  if GetModuleFileNameW(0, PWideChar(@S[1]), MAX_PATH) = 0 then
+  begin
+    // WritelnWarning('GetModuleFileNameW failed. We will use old method to determine ExeName, which will fail if parent directory contains local characters');
+    Exit(ParamStr(0)); // fallback to old method
+  end;
+  SetLength(S, StrLen(PWideChar(S))); // It's only null-terminated after WinAPI call, set actual length for Pascal UnicodeString
+  Result := UTF8Encode(S);
+{$else}
+begin
+  Result := ParamStr(0); // On non-Windows OSes, using ParamStr(0) for this is not reliable, but at least it's some default
+{$endif}
+end;
+
+function GetCastleEnginePathFromExeName: String;
+var
+  ToolDir: String;
+begin
+  ToolDir := ExtractFileDir(ExeName);
+
+  { in case we're inside macOS bundle, use bundle path.
+    This makes detection in case of CGE editor work OK. }
+  {$ifdef DARWIN}
+  // TODO: copy BundlePath from CGE? Or use CGE units here?
+  // if BundlePath <> '' then
+  //   ToolDir := ExtractFileDir(ExclPathDelim(BundlePath));
+  {$endif}
+
+  { Check ../ of current exe, makes sense in released CGE version when
+    tools are precompiled in bin/ subdirectory. }
+  Result := IncludeTrailingPathDelimiter(ExtractFileDir(ToolDir));
+  if CheckCastlePath(Result) then
+    Exit;
+  { Check ../../ of current exe, makes sense in development when
+    each tool is compiled by various scripts in tools/xxx/ subdirectory. }
+  Result := IncludeTrailingPathDelimiter(ExtractFileDir(ExtractFileDir(ToolDir)));
+  if CheckCastlePath(Result) then
+    Exit;
+
+  Result := '';
+end;
+
+function GetCastleEnginePathSystemWide: String;
+begin
+  {$ifdef UNIX}
+  Result := '/usr/src/castle-engine/';
+  if CheckCastlePath(Result) then
+    Exit;
+
+  Result := '/usr/local/src/castle-engine/';
+  if CheckCastlePath(Result) then
+    Exit;
+  {$endif}
+
+  Result := '';
+end;
+
+function GetCastleEnginePath: String;
+begin
+  // try to find CGE on $CASTLE_ENGINE_PATH
+  Result := GetCastleEnginePathFromEnv;
+  // try to find CGE on path relative to current exe
+  if Result = '' then
+    Result := GetCastleEnginePathFromExeName;
+  // try to find CGE on system-wide paths
+  if Result = '' then
+    Result := GetCastleEnginePathSystemWide;
+end;
+
 function ExtraFpcOptions: String;
 
   { Quote arguments passed to FPC in case they contain spaces.
@@ -98,108 +201,6 @@ function ExtraFpcOptions: String;
       Result := '"' + S + '"';
     end else
       Result := S;
-  end;
-
-  { Check is Path a sensible CGE sources path.
-    Requires Path to end with PathDelim. }
-  function CheckCastlePath(const Path: String): Boolean;
-  begin
-    Result :=
-      DirectoryExists(Path + 'src') and
-      DirectoryExists(Path + 'tools' + PathDelim + 'build-tool' + PathDelim + 'data');
-  end;
-
-  function GetCastleEnginePathFromEnv: String;
-  begin
-    Result := GetEnvironmentVariable('CASTLE_ENGINE_PATH');
-    if Result = '' then
-      Exit;
-
-    Result := IncludeTrailingPathDelimiter(Result);
-    if CheckCastlePath(Result) then
-      Exit;
-
-    Result := '';
-  end;
-
-  function ExeName: String;
-  {$if defined(LINUX)}
-  var
-    ExeLinkName: String;
-  begin
-    ExeLinkName := '/proc/' + IntToStr(FpGetpid) + '/exe';
-    Result := FpReadLink(ExeLinkName);
-  {$elseif defined(MSWINDOWS)}
-  var
-    S: UnicodeString;
-  begin
-    SetLength(S, MAX_PATH);
-    if GetModuleFileNameW(0, PWideChar(@S[1]), MAX_PATH) = 0 then
-    begin
-      // WritelnWarning('GetModuleFileNameW failed. We will use old method to determine ExeName, which will fail if parent directory contains local characters');
-      Exit(ParamStr(0)); // fallback to old method
-    end;
-    SetLength(S, StrLen(PWideChar(S))); // It's only null-terminated after WinAPI call, set actual length for Pascal UnicodeString
-    Result := UTF8Encode(S);
-  {$else}
-  begin
-    Result := ParamStr(0); // On non-Windows OSes, using ParamStr(0) for this is not reliable, but at least it's some default
-  {$endif}
-  end;
-
-  function GetCastleEnginePathFromExeName: String;
-  var
-    ToolDir: String;
-  begin
-    ToolDir := ExtractFileDir(ExeName);
-
-    { in case we're inside macOS bundle, use bundle path.
-      This makes detection in case of CGE editor work OK. }
-    {$ifdef DARWIN}
-    // TODO: copy BundlePath from CGE? Or use CGE units here?
-    // if BundlePath <> '' then
-    //   ToolDir := ExtractFileDir(ExclPathDelim(BundlePath));
-    {$endif}
-
-    { Check ../ of current exe, makes sense in released CGE version when
-      tools are precompiled in bin/ subdirectory. }
-    Result := IncludeTrailingPathDelimiter(ExtractFileDir(ToolDir));
-    if CheckCastlePath(Result) then
-      Exit;
-    { Check ../../ of current exe, makes sense in development when
-      each tool is compiled by various scripts in tools/xxx/ subdirectory. }
-    Result := IncludeTrailingPathDelimiter(ExtractFileDir(ExtractFileDir(ToolDir)));
-    if CheckCastlePath(Result) then
-      Exit;
-
-    Result := '';
-  end;
-
-  function GetCastleEnginePathSystemWide: String;
-  begin
-    {$ifdef UNIX}
-    Result := '/usr/src/castle-engine/';
-    if CheckCastlePath(Result) then
-      Exit;
-
-    Result := '/usr/local/src/castle-engine/';
-    if CheckCastlePath(Result) then
-      Exit;
-    {$endif}
-
-    Result := '';
-  end;
-
-  function GetCastleEnginePath: String;
-  begin
-    // try to find CGE on $CASTLE_ENGINE_PATH
-    Result := GetCastleEnginePathFromEnv;
-    // try to find CGE on path relative to current exe
-    if Result = '' then
-      Result := GetCastleEnginePathFromExeName;
-    // try to find CGE on system-wide paths
-    if Result = '' then
-      Result := GetCastleEnginePathSystemWide;
   end;
 
   function CastleOptionsFromCfg(CastleEnginePath: String): String;
@@ -268,6 +269,9 @@ end;
 procedure ParseWorkspacePaths(const ProjectSearchPaths, ProjectDirectory: String);
 var
   I: Integer;
+  CastleFpcCfg: TStringList;
+  UntrimmedS, S: String;
+  CastleEnginePath: String;
 begin
   if Trim(ProjectSearchPaths) = '' then
     Exit;
@@ -277,6 +281,25 @@ begin
     WorkspacePaths[I] := IncludeTrailingPathDelimiter(ProjectDirectory) + WorkspacePaths[I];
 
   WorkspacePaths.Insert(0, ProjectDirectory);
+
+
+  WorkspaceAndEnginePaths.Text := WorkspacePaths.Text;
+
+  CastleEnginePath := GetCastleEnginePath;
+
+  CastleFpcCfg := TStringList.Create;
+  try
+    CastleFpcCfg.LoadFromFile(CastleEnginePath + 'castle-fpc.cfg');
+    for UntrimmedS in CastleFpcCfg do
+    begin
+      S := Trim(UntrimmedS);
+      if S.Startswith('-Fu', true) then
+      begin
+        Delete(S, 1, 3);
+        WorkspaceAndEnginePaths.Add(CastleEnginePath + S);
+      end;
+    end;
+  finally FreeAndNil(CastleFpcCfg) end;
 end;
 
 

--- a/server/castlelsp.pas
+++ b/server/castlelsp.pas
@@ -197,8 +197,7 @@ function ExtraFpcOptions: String;
           { Quotes added because the path to the engine may have spaces.
             For example default AppData path on Windows }
           Insert('"' + CastleEnginePath, S, 4);
-          S := S + '"';
-          Result := Result + ' ' + S;
+          Result := Result + ' ' + S + '"';
         end;
       end;
     finally FreeAndNil(CastleFpcCfg) end;

--- a/server/castlelsp.pas
+++ b/server/castlelsp.pas
@@ -23,10 +23,13 @@ unit CastleLsp;
 
 interface
 
-uses IniFiles;
+uses Classes, IniFiles;
 
 var
   UserConfig: TIniFile;
+  WorkspacePaths: TStringList;
+  WorkspaceAndEnginePaths: TStringList;
+  EngineDeveloperMode: Boolean;
 
 procedure InitializeUserConfig;
 
@@ -39,6 +42,8 @@ procedure InitializeUserConfig;
 }
 function ExtraFpcOptions: String;
 
+procedure ParseWorkspacePaths(const ProjectSearchPaths, ProjectDirectory: String);
+
 implementation
 
 {$ifdef UNIX} {$define UNIX_WITH_USERS_UNIT} {$endif}
@@ -48,7 +53,7 @@ implementation
 uses
   {$ifdef MSWINDOWS} Windows, {$endif}
   {$ifdef UNIX_WITH_USERS_UNIT} BaseUnix, {UnixUtils, - cannot be found, masked by UnixUtil?} Users, {$endif}
-  SysUtils, Classes,
+  SysUtils,
   UDebug;
 
 procedure InitializeUserConfig;
@@ -259,6 +264,28 @@ begin
   end;
 end;
 
+
+procedure ParseWorkspacePaths(const ProjectSearchPaths, ProjectDirectory: String);
+var
+  I: Integer;
+begin
+  if Trim(ProjectSearchPaths) = '' then
+    Exit;
+
+  WorkspacePaths.Text := ProjectSearchPaths;
+  for I := 0 to WorkspacePaths.Count -1 do
+    WorkspacePaths[I] := IncludeTrailingPathDelimiter(ProjectDirectory) + WorkspacePaths[I];
+
+  WorkspacePaths.Insert(0, ProjectDirectory);
+end;
+
+
+initialization
+  WorkspacePaths := TStringList.Create;
+  WorkspaceAndEnginePaths := TStringList.Create;
+
 finalization
+  FreeAndNil(WorkspaceAndEnginePaths);
+  FreeAndNil(WorkspacePaths);
   FreeAndNil(UserConfig);
 end.

--- a/server/pasls.lpi
+++ b/server/pasls.lpi
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CONFIG>
   <ProjectOptions>
-    <Version Value="11"/>
+    <Version Value="12"/>
     <General>
       <Flags>
         <MainUnitHasCreateFormStatements Value="False"/>
+        <CompatibilityMode Value="True"/>
       </Flags>
       <SessionStorage Value="InProjectDir"/>
-      <MainUnit Value="0"/>
       <Title Value="pasls"/>
       <UseAppBundle Value="False"/>
       <ResourceType Value="res"/>
@@ -42,7 +42,6 @@
     </PublishOptions>
     <RunParams>
       <FormatVersion Value="2"/>
-      <Modes Count="0"/>
     </RunParams>
     <RequiredPackages Count="5">
       <Item1>
@@ -62,7 +61,7 @@
         <PackageName Value="FCL"/>
       </Item5>
     </RequiredPackages>
-    <Units Count="8">
+    <Units Count="11">
       <Unit0>
         <Filename Value="pasls.lpr"/>
         <IsPartOfProject Value="True"/>
@@ -95,6 +94,19 @@
         <Filename Value="uutils.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit7>
+      <Unit8>
+        <Filename Value="ulogvscode.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit8>
+      <Unit9>
+        <Filename Value="udocumentsymbolsupport.pas"/>
+        <IsPartOfProject Value="True"/>
+        <UnitName Value="UDocumentSymbolSupport"/>
+      </Unit9>
+      <Unit10>
+        <Filename Value="ushutdown.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit10>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/server/pasls.lpi
+++ b/server/pasls.lpi
@@ -61,7 +61,7 @@
         <PackageName Value="FCL"/>
       </Item5>
     </RequiredPackages>
-    <Units Count="11">
+    <Units Count="12">
       <Unit0>
         <Filename Value="pasls.lpr"/>
         <IsPartOfProject Value="True"/>

--- a/server/pasls.lpi
+++ b/server/pasls.lpi
@@ -107,6 +107,11 @@
         <Filename Value="ushutdown.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit10>
+      <Unit11>
+        <Filename Value="uworkspacesymbolsupport.pas"/>
+        <IsPartOfProject Value="True"/>
+        <UnitName Value="UWorkspaceSymbolSupport"/>
+      </Unit11>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/server/pasls.lpr
+++ b/server/pasls.lpr
@@ -26,7 +26,7 @@ uses
   Classes, SysUtils, iostream, streamex, StreamIO,
   udebug, ubufferedreader, jsonstream,
   upackages, ujsonrpc, uinitialize, utextdocument, uutils,
-  CastleLsp, ULogVSCode, UDocumentSymbolSupport, ushutdown;
+  CastleLsp, ULogVSCode, UDocumentSymbolSupport, ushutdown, UWorkspaceSymbolSupport;
 
 var
   ShouldExit: Boolean;
@@ -76,6 +76,13 @@ begin
     TextDocument_Definition(Rpc, Request)
   else if Request.Method = 'textDocument/documentSymbol' then
     TextDocument_DocumentSymbol(Rpc, Request)
+  else if Request.Method = 'workspace/symbol' then
+  begin
+    if EngineDeveloperMode then
+       TextDocument_WorkspaceSymbol(Rpc, Request, WorkspaceAndEnginePaths)
+    else
+       TextDocument_WorkspaceSymbol(Rpc, Request, WorkspacePaths);
+  end
   else if Request.Method = 'exit' then
   begin
     ShouldExit := true;

--- a/server/pasls.lpr
+++ b/server/pasls.lpr
@@ -26,7 +26,7 @@ uses
   Classes, SysUtils, iostream, streamex, StreamIO,
   udebug, ubufferedreader, jsonstream,
   upackages, ujsonrpc, uinitialize, utextdocument, uutils,
-  CastleLsp;
+  CastleLsp, ULogVSCode, UDocumentSymbolSupport;
 
 procedure SendError(
   Rpc: TRpcPeer; Id: TRpcId; Code: Integer; const Msg: string
@@ -62,6 +62,8 @@ begin
     TextDocument_Declaration(Rpc, Request)
   else if Request.Method = 'textDocument/definition' then
     TextDocument_Definition(Rpc, Request)
+  else if Request.Method = 'textDocument/documentSymbol' then
+    TextDocument_DocumentSymbol(Rpc, Request)
   else if Request.Method = 'exit' then
   else if Request.Method = '$/cancelRequest' then
   else if Request.Method = '$/setTrace' then

--- a/server/pasls.lpr
+++ b/server/pasls.lpr
@@ -64,6 +64,8 @@ begin
     TextDocument_Definition(Rpc, Request)
   else if Request.Method = 'exit' then
   else if Request.Method = '$/cancelRequest' then
+  else if Request.Method = '$/setTrace' then
+    TraceValue := ParseSetTrace(Request)
   else
     raise ERpcError.CreateFmt(
       jsrpcMethodNotFound, 'Method not found: %s', [Request.Method]

--- a/server/pasls.lpr
+++ b/server/pasls.lpr
@@ -79,9 +79,9 @@ begin
   else if Request.Method = 'workspace/symbol' then
   begin
     if EngineDeveloperMode then
-       TextDocument_WorkspaceSymbol(Rpc, Request, WorkspaceAndEnginePaths)
+       WorkspaceSymbol(Rpc, Request, WorkspaceAndEnginePaths)
     else
-       TextDocument_WorkspaceSymbol(Rpc, Request, WorkspacePaths);
+       WorkspaceSymbol(Rpc, Request, WorkspacePaths);
   end
   else if Request.Method = 'exit' then
   begin

--- a/server/pasls.lpr
+++ b/server/pasls.lpr
@@ -79,9 +79,9 @@ begin
   else if Request.Method = 'workspace/symbol' then
   begin
     if EngineDeveloperMode then
-       WorkspaceSymbol(Rpc, Request, WorkspaceAndEnginePaths)
+      WorkspaceSymbol(Rpc, Request, WorkspaceAndEnginePaths)
     else
-       WorkspaceSymbol(Rpc, Request, WorkspacePaths);
+      WorkspaceSymbol(Rpc, Request, WorkspacePaths);
   end
   else if Request.Method = 'exit' then
   begin

--- a/server/pasls.lpr
+++ b/server/pasls.lpr
@@ -26,7 +26,10 @@ uses
   Classes, SysUtils, iostream, streamex, StreamIO,
   udebug, ubufferedreader, jsonstream,
   upackages, ujsonrpc, uinitialize, utextdocument, uutils,
-  CastleLsp, ULogVSCode, UDocumentSymbolSupport;
+  CastleLsp, ULogVSCode, UDocumentSymbolSupport, ushutdown;
+
+var
+  ShouldExit: Boolean;
 
 procedure SendError(
   Rpc: TRpcPeer; Id: TRpcId; Code: Integer; const Msg: string
@@ -49,6 +52,7 @@ begin
     Initialize(Rpc, Request)
   else if Request.Method = 'initialized' then
   else if Request.Method = 'shutdown' then
+    Shutdown(Rpc, Request)
   else if Request.Method = 'textDocument/didOpen' then
     TextDocument_DidOpen(Rpc, Request)
   else if Request.Method = 'textDocument/didChange' then
@@ -65,6 +69,10 @@ begin
   else if Request.Method = 'textDocument/documentSymbol' then
     TextDocument_DocumentSymbol(Rpc, Request)
   else if Request.Method = 'exit' then
+  begin
+    ShouldExit := true;
+    DebugLog('Get exit message, exiting...');
+  end
   else if Request.Method = '$/cancelRequest' then
   else if Request.Method = '$/setTrace' then
     TraceValue := ParseSetTrace(Request)
@@ -88,6 +96,12 @@ begin
       begin  
         DebugLog('** End of stream, exiting **');
         exit;
+      end;
+
+      if ShouldExit then
+      begin
+        DebugLog('Main - exit');
+        Exit;
       end;
 
       try
@@ -179,6 +193,8 @@ begin
   Transcript     := nil;
   Tee            := nil;
   RpcPeer        := nil;
+  ShouldExit     := false;
+  WasShutdown    := false;
 
   ParseOptions;
 

--- a/server/pasls.lpr
+++ b/server/pasls.lpr
@@ -48,6 +48,14 @@ end;
 
 procedure Dispatch(Rpc: TRpcPeer; Request: TRpcRequest);
 begin
+  { When there was shutdown request all other request should
+   return InvalidRequest response, this is done by throwing ERpcError exception.
+   more info: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#shutdown}
+  if WasShutdown and (Request.Method <> 'exit') then
+    raise ERpcError.CreateFmt(
+      jsrpcInvalidRequest,
+      'Request after shutdown: (method: %s)', [Request.Method]);
+
   if Request.Method = 'initialize' then
     Initialize(Rpc, Request)
   else if Request.Method = 'initialized' then

--- a/server/udocumentsymbolsupport.pas
+++ b/server/udocumentsymbolsupport.pas
@@ -89,7 +89,7 @@ type
 
 implementation
 
-uses ulogvscode, CodeToolManager, CodeCache, CodeTree, PascalParserTool;
+uses ulogvscode, CodeToolManager, CodeCache, CodeTree, PascalParserTool{$ifdef WINDOWS}, LazUTF8{$endif};
 
 function Position(const ALine, ACharacter: Integer): TPosition;
 begin
@@ -195,7 +195,12 @@ begin
             include file that makes they do not work }
 
           //LogInfo(Rpc, 'Caret file name ' + StartCaret.Code.Filename);
+          //LogInfo(Rpc, 'Filename ' + Filename);
+          {$ifdef WINDOWS}
+          if UTF8CompareText(StartCaret.Code.Filename, Filename) <> 0 then
+          {$else}
           if StartCaret.Code.Filename <> Filename then
+          {$endif}
           begin
             Node := Node.Next;
             continue;

--- a/server/udocumentsymbolsupport.pas
+++ b/server/udocumentsymbolsupport.pas
@@ -171,8 +171,8 @@ begin
         // LogInfo(Rpc, 'Node: ' + Node.DescAsString);
         if Node.Desc = ctnProcedure then
         begin
-          LogInfo(Rpc, CodeTool.ExtractProcHead(Node, [phpAddParentProcs,
-            phpWithoutParamList, phpWithoutBrackets, phpWithoutSemicolon]));
+          { LogInfo(Rpc, CodeTool.ExtractProcHead(Node, [phpAddParentProcs,
+            phpWithoutParamList, phpWithoutBrackets, phpWithoutSemicolon])); }
 
           { Get the real position in source file }
           CodeTool.CleanPosToCaret(Node.StartPos, StartCaret);

--- a/server/udocumentsymbolsupport.pas
+++ b/server/udocumentsymbolsupport.pas
@@ -1,0 +1,243 @@
+unit UDocumentSymbolSupport;
+
+{
+  Implementation of DocumentSymbol
+
+  Docs: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentSymbol
+}
+
+{$mode ObjFPC}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, jsonstream, ujsonrpc, Generics.Collections, uutils, udebug;
+
+type
+  { Enumeration of symbol kinds based on
+    https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#symbolKind }
+  TDocumentSymbolKind = (
+    dskFile = 1,
+    dskModule,
+    dskNamespace,
+    dskPackage,
+    dskClass,
+    dskMethod,
+    dskProperty,
+    dskField,
+    dskConstructor,
+    dskEnum,
+    dskInterface,
+    dskFunction,
+    dskVariable,
+    dskConstant,
+    dskString,
+    dskNumber,
+    dskBoolean,
+    dskArray,
+    dskObject,
+    dskKey,
+    dskNull,
+    dskEnumMember,
+    dskStruct,
+    dskEvent,
+    dskOperator,
+    dskTypeOperator
+  );
+
+  TSymbolTag = (
+    stDeprecated
+  );
+
+  TSymbolTags = set of TSymbolTag;
+
+  { https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#position }
+  TPosition = record
+    Line: Integer;
+    Character: Integer;
+  end;
+
+  { https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#range }
+  TRange = record
+     Starts: TPosition;
+     Ends: TPosition;
+  end;
+
+
+  TDocumentSymbol = class;
+  TDocumentSymbolList = specialize TList<TDocumentSymbol>;
+
+  { Class based on
+    https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentSymbol }
+  TDocumentSymbol = class
+  public
+    Name: String;
+    Detail: String;
+    Kind: TDocumentSymbolKind;
+    SymbolTags: TSymbolTags;
+    Deprecated: Boolean;
+    Range: TRange;
+    SelectionRange: TRange;
+    Children: TDocumentSymbolList;
+  end;
+
+
+  function Position(const ALine, ACharacter: Integer): TPosition;
+  function Range(const AStarts, AEnds: TPosition): TRange;
+
+  procedure TextDocument_DocumentSymbol(Rpc: TRpcPeer; Request: TRpcRequest);
+
+implementation
+
+uses ulogvscode, CodeToolManager, CodeCache, CodeTree, PascalParserTool;
+
+function Position(const ALine, ACharacter: Integer): TPosition;
+begin
+  Result.Line := ALine;
+  Result.Character := ACharacter;
+end;
+
+function Range(const AStarts, AEnds: TPosition): TRange;
+begin
+  Result.Starts := AStarts;
+  Result.Ends := AEnds;
+end;
+
+
+function ParseDocumentSymbolRequest(Reader: TJsonReader): String;
+var
+  Key, Uri: String;
+begin
+  Uri := '';
+  if Reader.Dict then
+    while (Reader.Advance <> jsDictEnd) and Reader.Key(Key) do
+    begin
+      if (Key = 'textDocument') and Reader.Dict then
+        while (Reader.Advance <> jsDictEnd) and Reader.Key(Key) do
+        begin
+          if Key = 'uri' then
+          begin
+            Reader.Str(Uri);
+            break;
+          end;
+        end
+    end;
+  Result := URIToFileNameEasy(Uri);
+end;
+
+procedure TextDocument_DocumentSymbol(Rpc: TRpcPeer; Request: TRpcRequest);
+var
+  Filename: String;
+  Code: TCodeBuffer;
+  CodeTool: TCodeTool;
+  CodeTreeNode: TCodeTreeNode;
+
+  Node: TCodeTreeNode;
+
+  Response: TRpcResponse;
+  Writer:   TJsonWriter;
+begin
+  Filename := ParseDocumentSymbolRequest(Request.Reader);
+  LogMessage(Rpc, 'File name:' + Filename);
+  Code := CodeToolBoss.FindFile(Filename);
+
+  if Code = nil then
+    raise ERpcError.CreateFmt(
+      jsrpcInvalidRequest,
+      'File not found: %s', [Filename]
+    );
+
+ { Based on lazarus TProcedureListForm.GetCodeTreeNode() }
+
+  CodeToolBoss.Explore(Code, CodeTool, false, false);
+
+  if CodeTool = nil then
+    raise ERpcError.Create(jsrpcRequestFailed, 'File explore don''t return code tool.');
+
+  if CodeTool.Tree = nil then
+    raise ERpcError.Create(jsrpcRequestFailed, 'Code tool tree is nil.');
+
+  if CodeTool.Tree.Root = nil then
+    raise ERpcError.Create(jsrpcRequestFailed, 'Code tree root is nil.');
+
+  { Search for implementation node }
+  CodeTreeNode := CodeTool.FindImplementationNode;
+
+  { TODO: More debug lazarus in this case does something like
+    CodeTreeNode := CodeTool.Tree.Root, does it make sense for us? }
+  if CodeTreeNode = nil then
+    raise ERpcError.Create(jsrpcRequestFailed, 'Can''t find implementation section.');
+
+  Response := nil;
+  try
+    Response := TRpcResponse.Create(Request.Id);
+    Writer   := Response.Writer;
+
+    Writer.List;
+      { Based on lazarus TProcedureListForm.AddToGrid() }
+      Node := CodeTreeNode;
+      while Node <> nil do
+      begin
+        LogMessage(Rpc, 'Node: ' + Node.DescAsString);
+        if Node.Desc = ctnProcedure then
+        begin
+          LogMessage(Rpc, CodeTool.ExtractProcHead(Node, [phpAddParentProcs,
+            phpWithoutParamList, phpWithoutBrackets, phpWithoutSemicolon]));
+          Writer.Dict;
+            Writer.Key('name');
+            Writer.Str(CodeTool.ExtractProcHead(Node, [phpAddParentProcs,
+              phpWithoutParamList, phpWithoutBrackets, phpWithoutSemicolon]));
+
+            Writer.Key('kind');
+            Writer.Number(Integer(dskMethod));
+
+            Writer.Key('range');
+            Writer.Dict;
+              Writer.Key('start');
+              Writer.Dict;
+                Writer.Key('line');
+                Writer.Number(1);
+                Writer.Key('character');
+                Writer.Number(1);
+              Writer.DictEnd;
+              Writer.Key('end');
+              Writer.Dict;
+                Writer.Key('line');
+                Writer.Number(1);
+                Writer.Key('character');
+                Writer.Number(5);
+              Writer.DictEnd;
+            Writer.DictEnd;
+
+            Writer.Key('selectionRange');
+            Writer.Dict;
+              Writer.Key('start');
+              Writer.Dict;
+                Writer.Key('line');
+                Writer.Number(1);
+                Writer.Key('character');
+                Writer.Number(1);
+              Writer.DictEnd;
+              Writer.Key('end');
+              Writer.Dict;
+                Writer.Key('line');
+                Writer.Number(1);
+                Writer.Key('character');
+                Writer.Number(5);
+              Writer.DictEnd;
+            Writer.DictEnd;
+
+          Writer.DictEnd;
+        end;
+        Node := Node.Next;
+      end;
+    Writer.ListEnd;
+    Rpc.Send(Response);
+  finally
+    FreeAndNil(Response);
+  end;
+
+end;
+
+end.
+

--- a/server/udocumentsymbolsupport.pas
+++ b/server/udocumentsymbolsupport.pas
@@ -177,11 +177,11 @@ begin
     Writer   := Response.Writer;
 
     Writer.List;
-      { Based on lazarus TProcedureListForm.AddToGrid() }
+      { Based on lazarus TProcedureListForm.AddToGrid() and other functions }
       Node := CodeTreeNode;
       while Node <> nil do
       begin
-        LogInfo(Rpc, 'Node: ' + Node.DescAsString);
+        // LogInfo(Rpc, 'Node: ' + Node.DescAsString);
         if Node.Desc = ctnProcedure then
         begin
           LogInfo(Rpc, CodeTool.ExtractProcHead(Node, [phpAddParentProcs,
@@ -255,7 +255,6 @@ begin
   finally
     FreeAndNil(Response);
   end;
-
 end;
 
 end.

--- a/server/udocumentsymbolsupport.pas
+++ b/server/udocumentsymbolsupport.pas
@@ -138,7 +138,7 @@ var
   Writer:   TJsonWriter;
 begin
   Filename := ParseDocumentSymbolRequest(Request.Reader);
-  LogMessage(Rpc, 'File name:' + Filename);
+  LogInfo(Rpc, 'File name:' + Filename);
   Code := CodeToolBoss.FindFile(Filename);
 
   if Code = nil then
@@ -178,10 +178,10 @@ begin
       Node := CodeTreeNode;
       while Node <> nil do
       begin
-        LogMessage(Rpc, 'Node: ' + Node.DescAsString);
+        LogInfo(Rpc, 'Node: ' + Node.DescAsString);
         if Node.Desc = ctnProcedure then
         begin
-          LogMessage(Rpc, CodeTool.ExtractProcHead(Node, [phpAddParentProcs,
+          LogInfo(Rpc, CodeTool.ExtractProcHead(Node, [phpAddParentProcs,
             phpWithoutParamList, phpWithoutBrackets, phpWithoutSemicolon]));
           Writer.Dict;
             Writer.Key('name');

--- a/server/udocumentsymbolsupport.pas
+++ b/server/udocumentsymbolsupport.pas
@@ -55,7 +55,7 @@ type
 
 implementation
 
-uses ulogvscode, CodeToolManager, CodeCache, CodeTree, PascalParserTool{$ifdef WINDOWS}, LazUTF8{$endif};
+uses ulogvscode, CodeToolManager, CodeCache, CodeTree, PascalParserTool;
 
 function ParseDocumentSymbolRequest(Reader: TJsonReader): String;
 var
@@ -183,11 +183,7 @@ begin
 
           //LogInfo(Rpc, 'Caret file name ' + StartCaret.Code.Filename);
           //LogInfo(Rpc, 'Filename ' + Filename);
-          {$ifdef WINDOWS}
-          if UTF8CompareText(StartCaret.Code.Filename, Filename) <> 0 then
-          {$else}
-          if StartCaret.Code.Filename <> Filename then
-          {$endif}
+          if not SameFileName(StartCaret.Code.Filename, Filename) then
           begin
             Node := Node.Next;
             continue;

--- a/server/udocumentsymbolsupport.pas
+++ b/server/udocumentsymbolsupport.pas
@@ -136,6 +136,9 @@ var
 
   Response: TRpcResponse;
   Writer:   TJsonWriter;
+
+  StartCaret: TCodeXYPosition;
+  EndCaret: TCodeXYPosition;
 begin
   Filename := ParseDocumentSymbolRequest(Request.Reader);
   LogInfo(Rpc, 'File name:' + Filename);
@@ -191,21 +194,24 @@ begin
             Writer.Key('kind');
             Writer.Number(Integer(dskMethod));
 
+            CodeTool.CleanPosToCaret(Node.StartPos, StartCaret);
+            CodeTool.CleanPosToCaret(Node.EndPos, EndCaret);
+
             Writer.Key('range');
             Writer.Dict;
               Writer.Key('start');
               Writer.Dict;
                 Writer.Key('line');
-                Writer.Number(1);
+                Writer.Number(StartCaret.Y);
                 Writer.Key('character');
-                Writer.Number(1);
+                Writer.Number(StartCaret.X);
               Writer.DictEnd;
               Writer.Key('end');
               Writer.Dict;
                 Writer.Key('line');
-                Writer.Number(1);
+                Writer.Number(EndCaret.Y);
                 Writer.Key('character');
-                Writer.Number(5);
+                Writer.Number(EndCaret.X);
               Writer.DictEnd;
             Writer.DictEnd;
 
@@ -214,16 +220,16 @@ begin
               Writer.Key('start');
               Writer.Dict;
                 Writer.Key('line');
-                Writer.Number(1);
+                Writer.Number(StartCaret.Y);
                 Writer.Key('character');
-                Writer.Number(1);
+                Writer.Number(StartCaret.X);
               Writer.DictEnd;
               Writer.Key('end');
               Writer.Dict;
                 Writer.Key('line');
-                Writer.Number(1);
+                Writer.Number(StartCaret.Y);
                 Writer.Key('character');
-                Writer.Number(5);
+                Writer.Number(StartCaret.X);
               Writer.DictEnd;
             Writer.DictEnd;
 

--- a/server/udocumentsymbolsupport.pas
+++ b/server/udocumentsymbolsupport.pas
@@ -186,6 +186,21 @@ begin
         begin
           LogInfo(Rpc, CodeTool.ExtractProcHead(Node, [phpAddParentProcs,
             phpWithoutParamList, phpWithoutBrackets, phpWithoutSemicolon]));
+
+          { Get the real position in source file }
+          CodeTool.CleanPosToCaret(Node.StartPos, StartCaret);
+          CodeTool.CleanPosToCaret(Node.EndPos, EndCaret);
+
+          { Inc file support: do not add procedures those demand jump to another
+            include file that makes they do not work }
+
+          //LogInfo(Rpc, 'Caret file name ' + StartCaret.Code.Filename);
+          if StartCaret.Code.Filename <> Filename then
+          begin
+            Node := Node.Next;
+            continue;
+          end;
+
           Writer.Dict;
             Writer.Key('name');
             Writer.Str(CodeTool.ExtractProcHead(Node, [phpAddParentProcs,
@@ -194,8 +209,6 @@ begin
             Writer.Key('kind');
             Writer.Number(Integer(dskMethod));
 
-            CodeTool.CleanPosToCaret(Node.StartPos, StartCaret);
-            CodeTool.CleanPosToCaret(Node.EndPos, EndCaret);
 
             Writer.Key('range');
             Writer.Dict;

--- a/server/udocumentsymbolsupport.pas
+++ b/server/udocumentsymbolsupport.pas
@@ -94,6 +94,7 @@ var
 
   StartCaret: TCodeXYPosition;
   EndCaret: TCodeXYPosition;
+  ProcedureName: String;
 begin
   Filename := ParseDocumentSymbolRequest(Request.Reader);
   LogInfo(Rpc, 'File name:' + Filename);
@@ -192,10 +193,20 @@ begin
             continue;
           end;
 
+          ProcedureName := CodeTool.ExtractProcHead(Node, [phpAddParentProcs,
+              phpWithoutParamList, phpWithoutBrackets, phpWithoutSemicolon]);
+
+          { Check procedure name is not empty, that makes vscode returns errors.
+            Can happen when we start write new procedure. }
+          if Trim(ProcedureName) = '' then
+          begin
+            Node := Node.Next;
+            continue;
+          end;
+
           Writer.Dict;
             Writer.Key('name');
-            Writer.Str(CodeTool.ExtractProcHead(Node, [phpAddParentProcs,
-              phpWithoutParamList, phpWithoutBrackets, phpWithoutSemicolon]));
+            Writer.Str(ProcedureName);
 
             Writer.Key('kind');
             Writer.Number(Integer(dskMethod));

--- a/server/udocumentsymbolsupport.pas
+++ b/server/udocumentsymbolsupport.pas
@@ -11,7 +11,7 @@ unit UDocumentSymbolSupport;
 interface
 
 uses
-  Classes, SysUtils, jsonstream, ujsonrpc, Generics.Collections, uutils, udebug;
+  Classes, SysUtils, jsonstream, ujsonrpc, uutils;
 
 type
   { Enumeration of symbol kinds based on
@@ -51,58 +51,11 @@ type
 
   TSymbolTags = set of TSymbolTag;
 
-  { https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#position }
-  TPosition = record
-    Line: Integer;
-    Character: Integer;
-  end;
-
-  { https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#range }
-  TRange = record
-     Starts: TPosition;
-     Ends: TPosition;
-  end;
-
-
-  TDocumentSymbol = class;
-  TDocumentSymbolList = specialize TList<TDocumentSymbol>;
-
-  { Class based on
-    https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentSymbol }
-  TDocumentSymbol = class
-  public
-    Name: String;
-    Detail: String;
-    Kind: TDocumentSymbolKind;
-    SymbolTags: TSymbolTags;
-    Deprecated: Boolean;
-    Range: TRange;
-    SelectionRange: TRange;
-    Children: TDocumentSymbolList;
-  end;
-
-
-  function Position(const ALine, ACharacter: Integer): TPosition;
-  function Range(const AStarts, AEnds: TPosition): TRange;
-
   procedure TextDocument_DocumentSymbol(Rpc: TRpcPeer; Request: TRpcRequest);
 
 implementation
 
 uses ulogvscode, CodeToolManager, CodeCache, CodeTree, PascalParserTool{$ifdef WINDOWS}, LazUTF8{$endif};
-
-function Position(const ALine, ACharacter: Integer): TPosition;
-begin
-  Result.Line := ALine;
-  Result.Character := ACharacter;
-end;
-
-function Range(const AStarts, AEnds: TPosition): TRange;
-begin
-  Result.Starts := AStarts;
-  Result.Ends := AEnds;
-end;
-
 
 function ParseDocumentSymbolRequest(Reader: TJsonReader): String;
 var

--- a/server/uinitialize.pas
+++ b/server/uinitialize.pas
@@ -35,7 +35,7 @@ uses
   SysUtils, Classes, CodeToolManager, CodeToolsConfig, URIParser, LazUTF8,
   DefineTemplates, FileUtil, LazFileUtils, DOM, XMLRead, udebug, uutils,
   upackages, utextdocument,
-  CastleLsp, CastleArchitectures;
+  CastleLsp, CastleArchitectures, ULogVSCode;
 
 
 // Resolve the dependencies of Pkg, and then the dependencies of the

--- a/server/uinitialize.pas
+++ b/server/uinitialize.pas
@@ -599,11 +599,11 @@ begin
           while (Reader.Advance <> jsDictEnd) and Reader.Key(Key) do
           begin
             if (Key = 'PP') and Reader.Str(s) then
-              Options.FPCPath := s
+              Options.FPCPath := '"' + s + '"'
             else if (Key = 'FPCDIR') and Reader.Str(s) then
-              Options.FPCSrcDir := s
+              Options.FPCSrcDir := '"' + s + '"'
             else if (Key = 'LAZARUSDIR') and Reader.Str(s) then
-              Options.LazarusSrcDir := s
+              Options.LazarusSrcDir := '"' + s + '"'
             else if (Key = 'FPCTARGET') and Reader.Str(s) then
               Options.TargetOS := s
             else if (Key = 'FPCTARGETCPU') and Reader.Str(s) then

--- a/server/uinitialize.pas
+++ b/server/uinitialize.pas
@@ -615,6 +615,7 @@ var
   Key:       string;
   s:         string;
   i:         Integer;
+  b:         Boolean;
   ExtraOptions: String;
 
   RootUri:   string;
@@ -627,7 +628,6 @@ var
 begin
   Options  := nil;
   Response := nil;
-
   EngineDeveloperMode := false;
 
   try
@@ -676,6 +676,8 @@ begin
               StandardUnitsPaths := s
             else if (Key = 'projectSearchPaths') and Reader.Str(s) then
               ProjectSearchPaths := s
+            else if (Key = 'engineDevMode') and Reader.Bool(b) then
+              EngineDeveloperMode := b
             else if (Key = 'syntaxErrorReportingMode') and Reader.Number(i) then
               SyntaxErrorReportingMode := SyntaxErrorReportingModeFromInt(i);
           end;

--- a/server/uinitialize.pas
+++ b/server/uinitialize.pas
@@ -696,9 +696,9 @@ begin
         Writer.Str('Pascal Language Server');
       Writer.DictEnd;
 
-      Writer.Key('capabilities');
+      Writer.Key('capabilities');  // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#clientCapabilities
       Writer.Dict;
-        Writer.Key('textDocumentSync');
+        Writer.Key('textDocumentSync'); // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentSyncOptions
         Writer.Dict;
           Writer.Key('openClose');
           Writer.Bool(true);
@@ -737,6 +737,9 @@ begin
 
         Writer.Key('definitionProvider');
         Writer.Bool(true);
+
+        Writer.Key('documentSymbolProvider');
+        Writer.Bool(true);
       Writer.DictEnd;
 
       //Writer.Key('workspaceFolders');
@@ -744,6 +747,7 @@ begin
     Writer.DictEnd;
 
     Rpc.Send(Response);
+    LogTrace(Rpc, 'Initliasasas ');
   finally
     FreeAndNil(Options);
     FreeAndNil(Response);

--- a/server/uinitialize.pas
+++ b/server/uinitialize.pas
@@ -830,6 +830,9 @@ begin
 
         Writer.Key('documentSymbolProvider');
         Writer.Bool(true);
+
+        Writer.Key('workspaceSymbolProvider');
+        Writer.Bool(true);
       Writer.DictEnd;
 
       //Writer.Key('workspaceFolders');

--- a/server/uinitialize.pas
+++ b/server/uinitialize.pas
@@ -37,7 +37,6 @@ uses
   DOM, XMLRead, udebug, uutils, upackages, utextdocument,
   CastleLsp, CastleArchitectures, ULogVSCode;
 
-
 // Resolve the dependencies of Pkg, and then the dependencies of the
 // dependencies and so on. Uses global registry and paths locally specified in
 // the package/project file (.lpk/.lpi) as a data source.
@@ -629,6 +628,8 @@ begin
   Options  := nil;
   Response := nil;
 
+  EngineDeveloperMode := false;
+
   try
     Options := TCodeToolsOptions.Create;
     Options.InitWithEnvironmentVariables;
@@ -720,6 +721,7 @@ begin
     DebugLog(':: Castle Game Engine', []);
     ExtraOptions := ExtraFpcOptions;
     StandardUnitsPaths:= ParseStandardUnitsPaths(StandardUnitsPaths);
+    ParseWorkspacePaths(ProjectSearchPaths, Directory);
     ProjectSearchPaths := ParseProjectSearchPaths(ProjectSearchPaths, Directory);
     Options.FPCOptions := Options.FPCOptions + ' ' + ExtraOptions +
                        ' ' + StandardUnitsPaths + ' ' + ProjectSearchPaths;

--- a/server/uinitialize.pas
+++ b/server/uinitialize.pas
@@ -361,12 +361,10 @@ var
   Packages,
   SubDirectories:    TStringList;
   i:                 integer;
-  Paths:             TPaths;
 
   DirectoryTemplate,
   IncludeTemplate,
-  UnitPathTemplate,
-  SrcTemplate:       TDefineTemplate;
+  UnitPathTemplate: TDefineTemplate;
   Pkg:               TPackage;
 
 begin

--- a/server/uinitialize.pas
+++ b/server/uinitialize.pas
@@ -569,6 +569,8 @@ var
 
   RootUri:   string;
   Directory: string;
+  StandardUnitsPaths: string;
+  StandardUnitsPathsList: TStringList;
   Response:  TRpcResponse;
   Reader:    TJsonReader;
   Writer:    TJsonWriter;
@@ -618,10 +620,30 @@ begin
               Options.TargetOS := s
             else if (Key = 'FPCTARGETCPU') and Reader.Str(s) then
               Options.TargetProcessor := s
+            else if (Key = 'fpcStandardUnitsPaths') and Reader.Str(s) then
+              StandardUnitsPaths := s
             else if (Key = 'syntaxErrorReportingMode') and Reader.Number(i) then
               SyntaxErrorReportingMode := SyntaxErrorReportingModeFromInt(i);
           end;
       end;
+
+    DebugLog('StandardUnitsPaths: ' + StandardUnitsPaths + LineEnding);
+    if Trim(StandardUnitsPaths) <> '' then
+    begin
+      StandardUnitsPathsList := TStringList.Create;
+      StandardUnitsPathsList.Text := StandardUnitsPaths;
+      StandardUnitsPaths := '';
+      try
+        for i := 0 to StandardUnitsPathsList.Count -1 do
+        begin
+          if Trim(StandardUnitsPathsList[i]) = '' then
+             continue;
+          StandardUnitsPaths := StandardUnitsPaths + ' -Fu"' + StandardUnitsPathsList[i] + '"';
+        end;
+      finally
+        FreeAndNil(StandardUnitsPathsList);
+      end;
+    end;
 
     if Options.TargetOS = 'windows' then
     begin
@@ -662,8 +684,11 @@ begin
     DebugLog('', []);
     DebugLog(':: Castle Game Engine', []);
     ExtraOptions := ExtraFpcOptions;
-    Options.FPCOptions := Options.FPCOptions + ' ' + ExtraOptions;
-    DebugLog('  Adding compiler options: ' + ExtraOptions);
+    Options.FPCOptions := Options.FPCOptions + ' ' + ExtraOptions + ' ' + StandardUnitsPaths;
+    DebugLog('  Adding compiler extra options: ' + ExtraOptions + LineEnding);
+    if StandardUnitsPaths <> '' then
+       DebugLog('  Adding compiler standard Units Paths: ' + ExtraOptions + LineEnding);
+    DebugLog(' Options.FPCOptions : ' + Options.FPCOptions + LineEnding);
 
     DebugLog('', []);
     DebugLog(':: Searching global packages', []);

--- a/server/uinitialize.pas
+++ b/server/uinitialize.pas
@@ -485,15 +485,25 @@ var
 var
   CustomLazarusConfigDir: String;
 begin
+  { Preparing potential configuration folders and then trying to read
+    the settings from all of them one by one.
+    TODO: There can be potentional problem with order of checked path. }
+
   ConfigDirs := TStringList.Create;
   try
     CustomLazarusConfigDir := UserConfig.ReadString('lazarus', 'config', '');
     if CustomLazarusConfigDir <> '' then
       ConfigDirs.Add(ExcludeTrailingPathDelimiter(CustomLazarusConfigDir));
 
+    // add folder like C:\Users\<user>\AppData\Local\lazarus\
     ConfigDirs.Add(GetConfigDirForApp('lazarus', '', False));
+
+    // add folder like  C:\Users\<user>\\.lazarus
     ConfigDirs.Add(GetUserDir + DirectorySeparator + '.lazarus');
+
+    // add folder like C:\ProgramData\lazarus\
     ConfigDirs.Add(GetConfigDirForApp('lazarus', '', True));  ;
+
     for Dir in ConfigDirs do
     begin
       Doc := nil;

--- a/server/ulogvscode.pas
+++ b/server/ulogvscode.pas
@@ -1,0 +1,152 @@
+unit ULogVSCode;
+
+{$mode ObjFPC}{$H+}
+
+interface
+
+uses
+  sysutils, jsonstream, ujsonrpc;
+
+type
+
+  TVSCodeTraceValue = (
+    tvOff = 0,
+    tvMessages,
+    tvVerbose
+  );
+
+  { https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#messageType }
+  TVSCodeMessageLogType = (
+    mltError = 1,
+    mltWarning,
+    mltInfo,
+    mltLog,
+  );
+
+  function ParseSetTrace(const Request: TRpcRequest): TVSCodeTraceValue;
+  { Log Trace to work you need to add :
+    "pascal-language-server.trace.server": "verbose",
+    "pascal-language-server.trace.server": "messages",
+    to your settings.json.
+
+    Default value is "pascal-language-server.trace.server": "off". }
+  procedure LogTrace(const Rpc: TRpcPeer; const Message: String; const Verbose: String = '');
+
+  { https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_logMessage}
+  procedure LogError(const Rpc: TRpcPeer; const Message: String);
+  procedure LogWarning(const Rpc: TRpcPeer; const Message: String);
+  procedure LogInfo(const Rpc: TRpcPeer; const Message: String);
+  procedure LogMessage(const Rpc: TRpcPeer; const LogType: TVSCodeMessageLogType; const Message: String);
+
+var
+  TraceValue: TVSCodeTraceValue = tvOff;
+
+
+implementation
+
+uses udebug;
+
+{ https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#traceValue }
+function ParseSetTrace(const Request: TRpcRequest): TVSCodeTraceValue;
+var
+  Reader: TJsonReader;
+  Key: String;
+  Value: String;
+begin
+  Reader := Request.Reader;
+
+  if Reader.Dict then
+  begin
+    while (Reader.Advance <> jsDictEnd) and Reader.Key(Key) do
+    begin
+      if Key = 'value' then
+      begin
+        Reader.Str(Value);
+
+        if Value = 'off' then
+          Exit(tvOff)
+        else
+        if Value = 'message' then
+          Exit(tvMessages)
+        else
+        if Value = 'verbose' then
+          Exit(tvVerbose)
+        else
+        begin
+          DebugLog('ParseSetTrace uknown value: ' + Value);
+          Exit(tvVerbose);
+        end;
+      end;
+    end;
+  end;
+  Result := tvOff;
+end;
+
+{ https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#logTrace }
+procedure LogTrace(const Rpc: TRpcPeer; const Message: String; const Verbose: String = '');
+var
+  Notif: TRpcResponse;
+  Writer: TJsonWriter;
+begin
+  if TraceValue = tvOff then
+    Exit;
+
+  Notif := TRpcResponse.CreateNotification('$/logTrace');
+  try
+    Writer := Notif.Writer;
+    Writer.Key('params');
+    Writer.Dict;
+      Writer.Key('message');
+      Writer.Str(Message);
+      if TraceValue = tvVerbose then
+      begin
+        Writer.Key('verbose');
+        Writer.Str(Verbose);
+      end;
+    Writer.DictEnd;
+    Rpc.Send(Notif);
+  finally
+    FreeAndNil(Notif);
+  end;
+end;
+
+procedure LogError(const Rpc: TRpcPeer; const Message: String);
+begin
+  LogMessage(Rpc, mltError, Message);
+end;
+
+procedure LogWarning(const Rpc: TRpcPeer; const Message: String);
+begin
+  LogMessage(Rpc, mltWarning, Message);
+end;
+
+procedure LogInfo(const Rpc: TRpcPeer; const Message: String);
+begin
+  LogMessage(Rpc, mltInfo, Message);
+end;
+
+procedure LogMessage(const Rpc: TRpcPeer; const LogType: TVSCodeMessageLogType; const Message: String);
+var
+  Notif: TRpcResponse;
+  Writer: TJsonWriter;
+begin
+  Notif := TRpcResponse.CreateNotification('window/logMessage');
+  try
+    Writer := Notif.Writer;
+    Writer.Key('params');
+    Writer.Dict;
+      Writer.Key('type');
+      Writer.Number(Integer(LogType));
+
+      Writer.Key('message');
+      Writer.Str(Message);
+    Writer.DictEnd;
+    Rpc.Send(Notif);
+  finally
+    FreeAndNil(Notif);
+  end;
+end;
+
+
+end.
+

--- a/server/ulogvscode.pas
+++ b/server/ulogvscode.pas
@@ -20,7 +20,7 @@ type
     mltError = 1,
     mltWarning,
     mltInfo,
-    mltLog,
+    mltLog
   );
 
   function ParseSetTrace(const Request: TRpcRequest): TVSCodeTraceValue;

--- a/server/upackages.pas
+++ b/server/upackages.pas
@@ -131,6 +131,7 @@ begin
   try
     for Dir in SearchPaths do
     begin
+      DebugLog(' PopulateGlobalPackages Search path ' + Dir + #13#10);
       DebugLog('  %s/*.lpk', [Dir]);
       FindAllFiles(Files, Dir, '*.lpk');
     end;
@@ -138,9 +139,10 @@ begin
     for FileName in Files do
     begin
       Name := ExtractFileNameOnly(FileName);
+      DebugLog(' Global Package: ' + UpperCase(Name) + '  :' + FileName + #13#10);
       PkgNameToPath[UpperCase(Name)] := FileName;
     end;
-    DebugLog('  Found %d packages', [Files.Count]);
+    DebugLog('  Found %d packages' + #13#10, [Files.Count]);
 
   finally
     Files.Free;

--- a/server/upackages.pas
+++ b/server/upackages.pas
@@ -131,7 +131,7 @@ begin
   try
     for Dir in SearchPaths do
     begin
-      DebugLog(' PopulateGlobalPackages Search path ' + Dir + #13#10);
+      DebugLog(' PopulateGlobalPackages search path ' + Dir + LineEnding);
       DebugLog('  %s/*.lpk', [Dir]);
       FindAllFiles(Files, Dir, '*.lpk');
     end;
@@ -139,11 +139,10 @@ begin
     for FileName in Files do
     begin
       Name := ExtractFileNameOnly(FileName);
-      DebugLog(' Global Package: ' + UpperCase(Name) + '  :' + FileName + #13#10);
+      DebugLog(' Global Package: ' + UpperCase(Name) + '  :' + FileName + LineEnding);
       PkgNameToPath[UpperCase(Name)] := FileName;
     end;
-    DebugLog('  Found %d packages' + #13#10, [Files.Count]);
-
+    DebugLog('  Found %d packages', [Files.Count]);
   finally
     Files.Free;
   end;

--- a/server/ushutdown.pas
+++ b/server/ushutdown.pas
@@ -1,0 +1,47 @@
+unit ushutdown;
+
+{$mode ObjFPC}{$H+}
+
+interface
+
+uses
+  jsonstream, ujsonrpc;
+
+procedure Shutdown(Rpc: TRpcPeer; Request: TRpcRequest);
+
+var
+  WasShutdown: Boolean;
+
+implementation
+
+uses SysUtils, Classes, udebug;
+
+{
+  When client wants to stop lsp server send shutdown message and after
+  it get response (null). Send second message exit to simply close the server.
+
+  https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#shutdown
+}
+procedure Shutdown(Rpc: TRpcPeer; Request: TRpcRequest);
+var
+  Response: TRpcResponse;
+  Writer:   TJsonWriter;
+
+begin
+  DebugLog('Get shutdown message, waiting for exit...');
+  WasShutdown := true;
+
+  Response := nil;
+  try
+    Response := TRpcResponse.Create(Request.Id);
+    Writer   := Response.Writer;
+
+    Writer.Null;
+    Rpc.Send(Response);
+  finally
+    FreeAndNil(Response);
+  end;
+end;
+
+end.
+

--- a/server/utextdocument.pas
+++ b/server/utextdocument.pas
@@ -49,7 +49,7 @@ implementation
 uses
   Classes, SysUtils, URIParser, CodeToolManager, CodeCache, IdentCompletionTool,
   BasicCodeTools, PascalParserTool, CodeTree, FindDeclarationTool, LinkScanner,
-  CustomCodeTool, udebug;
+  CustomCodeTool, udebug, ulogvscode, uutils;
 
 function ParseChangeOrOpen(
   Reader: TJsonReader; out Uri: string; out Content: string; IsChange: Boolean
@@ -83,20 +83,6 @@ begin
         end;
     end;
   Result := HaveUri and HaveContent;
-end;
-
-{ Convert URI (with file:// protocol) to a filename.
-  Accepts also empty string, returning empty string in return.
-  Other / invalid URIs result in an exception. }
-function URIToFileNameEasy(const UriStr: String): String;
-begin
-  if UriStr = '' then
-    Exit('');
-  if not URIToFilename(UriStr, Result) then
-    raise ERpcError.CreateFmt(
-      jsrpcInvalidRequest,
-      'Unable to convert URI to filename: %s', [UriStr]
-    );
 end;
 
 procedure TextDocument_DidOpen(Rpc: TRpcPeer; Request: TRpcRequest);
@@ -689,6 +675,9 @@ var
   Success:           Boolean;
 
 begin
+  LogTrace(Rpc, 'test1234');
+  LogMessage(Rpc, 'TEst logu');
+
   Response := nil;
   Success  := false;
   IsProc   := false;

--- a/server/utextdocument.pas
+++ b/server/utextdocument.pas
@@ -109,7 +109,8 @@ begin
   begin
     FileName := URIToFileNameEasy(UriStr);
     Code := CodeToolBoss.LoadFile(FileName, false, false);
-    { When we can't found file try to create it }
+    { When we can't found file try to create it, workaround for creating
+      new source files in vscode }
     if Code = nil then
       Code := CodeToolBoss.CreateFile(FileName);
     if Code = nil then

--- a/server/utextdocument.pas
+++ b/server/utextdocument.pas
@@ -675,9 +675,6 @@ var
   Success:           Boolean;
 
 begin
-  LogTrace(Rpc, 'test1234');
-  LogMessage(Rpc, 'TEst logu');
-
   Response := nil;
   Success  := false;
   IsProc   := false;

--- a/server/utextdocument.pas
+++ b/server/utextdocument.pas
@@ -49,7 +49,7 @@ implementation
 uses
   Classes, SysUtils, URIParser, CodeToolManager, CodeCache, IdentCompletionTool,
   BasicCodeTools, PascalParserTool, CodeTree, FindDeclarationTool, LinkScanner,
-  CustomCodeTool, udebug, ulogvscode, uutils;
+  CustomCodeTool, udebug, uutils;
 
 function ParseChangeOrOpen(
   Reader: TJsonReader; out Uri: string; out Content: string; IsChange: Boolean

--- a/server/utextdocument.pas
+++ b/server/utextdocument.pas
@@ -757,7 +757,14 @@ begin
       end;
     except
       on E: ECodeToolError do
-        ShowErrorMessage(Rpc, E.Message);
+      begin
+        // exeption raised when we search identifier in some comments words
+        // has id 20170421200105 so we then do not show message window in vscode
+        if E.Id <> 20170421200105 then
+        begin
+          ShowErrorMessage(Rpc, E.Message);
+        end;
+      end;
       { ELinkScannerError is raised from FindDeclaration e.g. when include file is missing.
         Without capturing it here, trying to jump to declarations when there's an error
         would crash pasls server. }

--- a/server/utextdocument.pas
+++ b/server/utextdocument.pas
@@ -108,7 +108,10 @@ begin
   if ParseChangeOrOpen(Request.Reader, UriStr, Content, false) then
   begin
     FileName := URIToFileNameEasy(UriStr);
-    Code     := CodeToolBoss.LoadFile(FileName, false, false);
+    Code := CodeToolBoss.LoadFile(FileName, false, false);
+    { When we can't found file try to create it }
+    if Code = nil then
+      Code := CodeToolBoss.CreateFile(FileName);
     if Code = nil then
       raise ERpcError.CreateFmt(
         jsrpcInvalidRequest,

--- a/server/uutils.pas
+++ b/server/uutils.pas
@@ -25,11 +25,12 @@ interface
 
 function MergePaths(Paths: array of string): string;
 function GetConfigDirForApp(AppName, Vendor: string; Global: Boolean): string;
+function URIToFileNameEasy(const UriStr: String): String;
 
 implementation
 
 uses
-  sysutils;
+  SysUtils, URIParser, ujsonrpc;
 
 function MergePaths(Paths: array of string): string;
 var
@@ -78,6 +79,21 @@ begin
     OnGetVendorName      := OldGetVendorName;
   end;
 end;
+
+{ Convert URI (with file:// protocol) to a filename.
+  Accepts also empty string, returning empty string in return.
+  Other / invalid URIs result in an exception. }
+function URIToFileNameEasy(const UriStr: String): String;
+begin
+  if UriStr = '' then
+    Exit('');
+  if not URIToFilename(UriStr, Result) then
+    raise ERpcError.CreateFmt(
+      jsrpcInvalidRequest,
+      'Unable to convert URI to filename: %s', [UriStr]
+    );
+end;
+
 
 end.
 

--- a/server/uworkspacesymbolsupport.pas
+++ b/server/uworkspacesymbolsupport.pas
@@ -1,0 +1,296 @@
+unit UWorkspaceSymbolSupport;
+
+{
+  Implementation of WorkspaceSymbol
+
+  Docs: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_symbol
+}
+
+{$mode ObjFPC}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, jsonstream, ujsonrpc, uutils;
+
+type
+  { Enumeration of symbol kinds based on
+    https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#symbolKind }
+  TSymbolKind = (
+    skFile = 1,
+    skModule,
+    skNamespace,
+    skPackage,
+    skClass,
+    skMethod,
+    skProperty,
+    skField,
+    skConstructor,
+    skEnum,
+    skInterface,
+    skFunction,
+    skVariable,
+    skConstant,
+    skString,
+    skNumber,
+    skBoolean,
+    skArray,
+    skObject,
+    skKey,
+    skNull,
+    skEnumMember,
+    skStruct,
+    skEvent,
+    skOperator,
+    skTypeOperator
+  );
+
+  TSymbolTag = (
+    stDeprecated
+  );
+
+  TSymbolTags = set of TSymbolTag;
+
+  procedure TextDocument_WorkspaceSymbol(Rpc: TRpcPeer; Request: TRpcRequest; const Directories: TStrings);
+
+implementation
+
+uses ulogvscode, CodeToolManager, CodeCache, CodeTree, URIParser, PascalParserTool{$ifdef WINDOWS}, LazUTF8{$endif};
+
+function ParseDocumentSymbolRequest(Reader: TJsonReader): String;
+var
+  Key, Uri: String;
+begin
+  Uri := '';
+  if Reader.Dict then
+    while (Reader.Advance <> jsDictEnd) and Reader.Key(Key) do
+    begin
+      if Key = 'query' then
+      begin
+        Reader.Str(Uri);
+        break;
+      end;
+    end;
+  Result := URIToFileNameEasy(Uri);
+end;
+
+{ Responses for textDocument/documentSymbol method
+  Docs: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_symbol }
+procedure TextDocument_WorkspaceSymbol(Rpc: TRpcPeer; Request: TRpcRequest; const Directories: TStrings);
+var
+  FileName, Query: String;
+  Code: TCodeBuffer;
+  CodeTool: TCodeTool;
+  CodeTreeNode: TCodeTreeNode;
+
+  Node: TCodeTreeNode;
+
+  Response: TRpcResponse;
+  Writer:   TJsonWriter;
+
+  StartCaret: TCodeXYPosition;
+  EndCaret: TCodeXYPosition;
+  ProcedureName: String;
+  Count: Integer;
+//  IdentifierList: TIdentifierList;
+
+  Files: TStrings;
+  FilesWithPaths: TStringList;
+  I, J: Integer;
+  Directory: String;
+begin
+  Query := ParseDocumentSymbolRequest(Request.Reader);
+  LogInfo(Rpc, 'Query:' + Query);
+
+  FilesWithPaths := TStringList.Create;
+  try
+    Files := TStringList.Create;
+    try
+      for I := 0 to Directories.Count - 1 do
+      begin
+        Directory := IncludeTrailingPathDelimiter(Directories[I]);
+        LogInfo(Rpc, 'Directory1:' + Directory);
+        LogInfo(Rpc, 'Directory2:' + Directories[I]);
+        Files.Clear;
+
+        CodeToolBoss.SourceCache.DirectoryCachePool.GetListing(Directory, Files, false);
+
+        for J := 0 to Files.Count - 1 do
+        begin
+          FileName := Files[J];
+          if LowerCase(ExtractFileExt(FileName)) <> '.pas' then
+             continue;
+          FilesWithPaths.Add(Directory + FileName);
+          LogInfo(Rpc, 'File:' + FileName);
+          LogInfo(Rpc, 'FileWithPaths:' + Directory + FileName);
+        end;
+      end;
+    finally
+      FreeAndNil(Files);
+    end;
+
+    Response := nil;
+    try
+      Response := TRpcResponse.Create(Request.Id);
+      Writer   := Response.Writer;
+
+      Writer.List;
+      for I := 0  to FilesWithPaths.Count -1 do
+      begin
+        FileName := FilesWithPaths[I];
+
+        Code := CodeToolBoss.FindFile(Filename);
+
+        if Code = nil then
+        begin
+          Code := CodeToolBoss.LoadFile(FileName,false, false);
+          if Code = nil then
+          begin
+            LogInfo(Rpc, 'aha0');
+            Continue;
+          end;
+{          raise ERpcError.CreateFmt(
+            jsrpcInvalidRequest,
+            'File not found: %s', [Filename]
+          );}
+        end;
+
+        CodeToolBoss.Explore(Code, CodeTool, false, false);
+
+        if CodeTool = nil then
+        begin
+          LogInfo(Rpc, 'aha1');
+          raise ERpcError.Create(jsrpcRequestFailed, 'File explore don''t return code tool.');
+        end;
+
+        if CodeTool.Tree = nil then
+        begin
+          LogInfo(Rpc, 'aha2');
+          raise ERpcError.Create(jsrpcRequestFailed, 'Code tool tree is nil.');
+        end;
+
+        { This check fails when pas file is empty, return null in response }
+        if CodeTool.Tree.Root = nil then
+        begin
+          LogInfo(Rpc, 'aha3');
+          Continue;
+        end;
+
+
+        CodeTreeNode := CodeTool.FindInterfaceNode;
+
+        if CodeTreeNode = nil then
+        begin
+          LogInfo(Rpc, 'aha4');
+          Continue;
+        end;
+
+        { Based on lazarus TProcedureListForm.AddToGrid() and other functions }
+        Node := CodeTreeNode;
+        while Node <> nil do
+        begin
+          // LogInfo(Rpc, 'Node: ' + Node.DescAsString);
+          if Node.Desc = ctnProcedure then
+          begin
+            LogInfo(Rpc, CodeTool.ExtractProcHead(Node, [phpAddParentProcs,
+              phpWithoutParamList, phpWithoutBrackets, phpWithoutSemicolon]));
+
+            { Get the real position in source file }
+            CodeTool.CleanPosToCaret(Node.StartPos, StartCaret);
+            CodeTool.CleanPosToCaret(Node.EndPos, EndCaret);
+
+            ProcedureName := CodeTool.ExtractProcHead(Node, [phpAddParentProcs,
+                phpWithoutParamList, phpWithoutBrackets, phpWithoutSemicolon]);
+
+            { Check procedure name is not empty, that makes vscode returns errors.
+              Can happen when we start write new procedure. }
+            if Trim(ProcedureName) = '' then
+            begin
+              Node := Node.Next;
+              continue;
+            end;
+
+            Writer.Dict;
+              Writer.Key('name');
+              Writer.Str(ProcedureName);
+
+              Writer.Key('kind');
+              Writer.Number(Integer(skMethod));
+
+              Writer.Key('location');
+              Writer.Dict;
+                Writer.Key('uri');
+                Writer.Str(FilenameToURI(FileName));
+                Writer.Key('range');
+                Writer.Dict;
+                  Writer.Key('start');
+                  Writer.Dict;
+                    Writer.Key('line');
+                    Writer.Number(StartCaret.Y - 1 );
+                    Writer.Key('character');
+                    Writer.Number(StartCaret.X);
+                  Writer.DictEnd;
+                  Writer.Key('end');
+                  Writer.Dict;
+                    Writer.Key('line');
+                    Writer.Number(EndCaret.Y - 1);
+                    Writer.Key('character');
+                    Writer.Number(EndCaret.X);
+                  Writer.DictEnd;
+                Writer.DictEnd;
+              Writer.DictEnd;
+              {Writer.Key('range');
+              Writer.Dict;
+                Writer.Key('start');
+                Writer.Dict;
+                  Writer.Key('line');
+                  Writer.Number(StartCaret.Y);
+                  Writer.Key('character');
+                  Writer.Number(StartCaret.X);
+                Writer.DictEnd;
+                Writer.Key('end');
+                Writer.Dict;
+                  Writer.Key('line');
+                  Writer.Number(EndCaret.Y);
+                  Writer.Key('character');
+                  Writer.Number(EndCaret.X);
+                Writer.DictEnd;
+              Writer.DictEnd;
+
+              Writer.Key('selectionRange');
+              Writer.Dict;
+                Writer.Key('start');
+                Writer.Dict;
+                  Writer.Key('line');
+                  Writer.Number(StartCaret.Y);
+                  Writer.Key('character');
+                  Writer.Number(StartCaret.X);
+                Writer.DictEnd;
+                Writer.Key('end');
+                Writer.Dict;
+                  Writer.Key('line');
+                  Writer.Number(StartCaret.Y);
+                  Writer.Key('character');
+                  Writer.Number(StartCaret.X);
+                Writer.DictEnd;
+              Writer.DictEnd;}
+
+            Writer.DictEnd;
+          end;
+          Node := Node.Next;
+        end;
+
+      end;
+      Writer.ListEnd;
+      Rpc.Send(Response);
+    finally
+      FreeAndNil(Response);
+    end;
+
+  finally
+    FreeAndNil(FilesWithPaths);
+  end;
+end;
+
+end.
+

--- a/server/uworkspacesymbolsupport.pas
+++ b/server/uworkspacesymbolsupport.pas
@@ -51,7 +51,7 @@ type
 
   TSymbolTags = set of TSymbolTag;
 
-  procedure TextDocument_WorkspaceSymbol(Rpc: TRpcPeer; Request: TRpcRequest; const Directories: TStrings);
+  procedure WorkspaceSymbol(Rpc: TRpcPeer; Request: TRpcRequest; const Directories: TStrings);
 
 implementation
 
@@ -76,7 +76,7 @@ end;
 
 { Responses for textDocument/documentSymbol method
   Docs: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_symbol }
-procedure TextDocument_WorkspaceSymbol(Rpc: TRpcPeer; Request: TRpcRequest; const Directories: TStrings);
+procedure WorkspaceSymbol(Rpc: TRpcPeer; Request: TRpcRequest; const Directories: TStrings);
 var
   FileName, Query: String;
   Code: TCodeBuffer;
@@ -91,8 +91,6 @@ var
   StartCaret: TCodeXYPosition;
   EndCaret: TCodeXYPosition;
   ProcedureName: String;
-  Count: Integer;
-//  IdentifierList: TIdentifierList;
 
   Files: TStrings;
   FilesWithPaths: TStringList;

--- a/server/uworkspacesymbolsupport.pas
+++ b/server/uworkspacesymbolsupport.pas
@@ -55,7 +55,7 @@ type
 
 implementation
 
-uses ulogvscode, CodeToolManager, CodeCache, CodeTree, URIParser, PascalParserTool{$ifdef WINDOWS}, LazUTF8{$endif};
+uses ulogvscode, CodeToolManager, CodeCache, CodeTree, URIParser, PascalParserTool;
 
 function ParseDocumentSymbolRequest(Reader: TJsonReader): String;
 var

--- a/server/uworkspacesymbolsupport.pas
+++ b/server/uworkspacesymbolsupport.pas
@@ -143,45 +143,25 @@ begin
         begin
           Code := CodeToolBoss.LoadFile(FileName,false, false);
           if Code = nil then
-          begin
-            LogInfo(Rpc, 'aha0');
             Continue;
-          end;
-{          raise ERpcError.CreateFmt(
-            jsrpcInvalidRequest,
-            'File not found: %s', [Filename]
-          );}
         end;
 
         CodeToolBoss.Explore(Code, CodeTool, false, false);
 
         if CodeTool = nil then
-        begin
-          LogInfo(Rpc, 'aha1');
           raise ERpcError.Create(jsrpcRequestFailed, 'File explore don''t return code tool.');
-        end;
 
         if CodeTool.Tree = nil then
-        begin
-          LogInfo(Rpc, 'aha2');
           raise ERpcError.Create(jsrpcRequestFailed, 'Code tool tree is nil.');
-        end;
 
         { This check fails when pas file is empty, return null in response }
         if CodeTool.Tree.Root = nil then
-        begin
-          LogInfo(Rpc, 'aha3');
           Continue;
-        end;
-
 
         CodeTreeNode := CodeTool.FindInterfaceNode;
 
         if CodeTreeNode = nil then
-        begin
-          LogInfo(Rpc, 'aha4');
           Continue;
-        end;
 
         { Based on lazarus TProcedureListForm.AddToGrid() and other functions }
         Node := CodeTreeNode;

--- a/server/uworkspacesymbolsupport.pas
+++ b/server/uworkspacesymbolsupport.pas
@@ -158,7 +158,10 @@ begin
         if CodeTool.Tree.Root = nil then
           Continue;
 
-        CodeTreeNode := CodeTool.FindInterfaceNode;
+        CodeTreeNode := CodeTool.FindImplementationNode;
+        { When there is no implementation section try to parse interface }
+        if CodeTreeNode = nil then
+          CodeTreeNode := CodeTool.FindInterfaceNode;
 
         if CodeTreeNode = nil then
           Continue;

--- a/server/uworkspacesymbolsupport.pas
+++ b/server/uworkspacesymbolsupport.pas
@@ -202,7 +202,7 @@ begin
               Writer.Key('location');
               Writer.Dict;
                 Writer.Key('uri');
-                Writer.Str(FilenameToURI(FileName));
+                Writer.Str(FilenameToURI(StartCaret.Code.Filename));
                 Writer.Key('range');
                 Writer.Dict;
                   Writer.Key('start');
@@ -221,42 +221,6 @@ begin
                   Writer.DictEnd;
                 Writer.DictEnd;
               Writer.DictEnd;
-              {Writer.Key('range');
-              Writer.Dict;
-                Writer.Key('start');
-                Writer.Dict;
-                  Writer.Key('line');
-                  Writer.Number(StartCaret.Y);
-                  Writer.Key('character');
-                  Writer.Number(StartCaret.X);
-                Writer.DictEnd;
-                Writer.Key('end');
-                Writer.Dict;
-                  Writer.Key('line');
-                  Writer.Number(EndCaret.Y);
-                  Writer.Key('character');
-                  Writer.Number(EndCaret.X);
-                Writer.DictEnd;
-              Writer.DictEnd;
-
-              Writer.Key('selectionRange');
-              Writer.Dict;
-                Writer.Key('start');
-                Writer.Dict;
-                  Writer.Key('line');
-                  Writer.Number(StartCaret.Y);
-                  Writer.Key('character');
-                  Writer.Number(StartCaret.X);
-                Writer.DictEnd;
-                Writer.Key('end');
-                Writer.Dict;
-                  Writer.Key('line');
-                  Writer.Number(StartCaret.Y);
-                  Writer.Key('character');
-                  Writer.Number(StartCaret.X);
-                Writer.DictEnd;
-              Writer.DictEnd;}
-
             Writer.DictEnd;
           end;
           Node := Node.Next;

--- a/server/uworkspacesymbolsupport.pas
+++ b/server/uworkspacesymbolsupport.pas
@@ -107,8 +107,8 @@ begin
       for I := 0 to Directories.Count - 1 do
       begin
         Directory := IncludeTrailingPathDelimiter(Directories[I]);
-        LogInfo(Rpc, 'Directory1:' + Directory);
-        LogInfo(Rpc, 'Directory2:' + Directories[I]);
+        //LogInfo(Rpc, 'Directory1:' + Directory);
+        //LogInfo(Rpc, 'Directory2:' + Directories[I]);
         Files.Clear;
 
         CodeToolBoss.SourceCache.DirectoryCachePool.GetListing(Directory, Files, false);
@@ -119,8 +119,8 @@ begin
           if LowerCase(ExtractFileExt(FileName)) <> '.pas' then
              continue;
           FilesWithPaths.Add(Directory + FileName);
-          LogInfo(Rpc, 'File:' + FileName);
-          LogInfo(Rpc, 'FileWithPaths:' + Directory + FileName);
+          //LogInfo(Rpc, 'File:' + FileName);
+          //LogInfo(Rpc, 'FileWithPaths:' + Directory + FileName);
         end;
       end;
     finally
@@ -173,10 +173,11 @@ begin
           // LogInfo(Rpc, 'Node: ' + Node.DescAsString);
           if Node.Desc = ctnProcedure then
           begin
-            LogInfo(Rpc, CodeTool.ExtractProcHead(Node, [phpAddParentProcs,
-              phpWithoutParamList, phpWithoutBrackets, phpWithoutSemicolon]));
+            { LogInfo(Rpc, CodeTool.ExtractProcHead(Node, [phpAddParentProcs,
+              phpWithoutParamList, phpWithoutBrackets, phpWithoutSemicolon])); }
 
             { Get the real position in source file }
+
             CodeTool.CleanPosToCaret(Node.StartPos, StartCaret);
             CodeTool.CleanPosToCaret(Node.EndPos, EndCaret);
 


### PR DESCRIPTION
Most important changes:
- fixed error when new file created
- proper server shutdown 
- document symbol support (Ctrl+Shift+o) to show list of file procedures
- support for bundled fpc (without fpc.cfg) - path is provided by vscode extension
- do not show error when search identifier in comments
- support to log (trace) directly to vscode