### PR TITLE
Fixed close code completion on hit space, add keywords, code completion icons

### DIFF
--- a/server/utextdocument.pas
+++ b/server/utextdocument.pas
@@ -353,6 +353,12 @@ begin
     Writer.Key('label');
     Writer.Str(Rec.Text);
 
+    // text used to filter
+    Writer.Key('filterText');
+    Writer.Str(
+      Copy(Rec.Text, Rec.Identifier.a, Rec.Identifier.b - Rec.Identifier.a)
+    );
+
     Writer.Key('detail');
     Writer.Str(Rec.Desc);
   Writer.DictEnd;

--- a/server/utextdocument.pas
+++ b/server/utextdocument.pas
@@ -530,6 +530,8 @@ begin
           Copy(Rec.Text, Rec.Identifier.a, Rec.Identifier.b - Rec.Identifier.a)
         );
 
+        AddIdentifierKind(Rec, Writer);
+
         { https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItemLabelDetails }
         {Writer.Key('labelDetails');
         Writer.Dict;


### PR DESCRIPTION
This PR fixes annoying bug that code completion is not closed when you hit space.
Also a lot of other work like:

- icons for code completion items:
![obraz](https://github.com/Isopod/pascal-language-server/assets/18555708/690ddac0-f18c-4835-8b34-85bd2130a93f)
- adds keywords to code completion
- code completion styles - TIdentifierCodeCompletionStyle for different autocompletion styles that shows only identifiers without parameters and all overloaded  functions or old way that is currently default ( ccsShowOnlyUniqueIdentifier need more work I think)
- ability to filter overloaded functions

Do not know it's ready for merge (result of one coding session) please test